### PR TITLE
infra: provision AWS + Auth0 via Terraform (Plan 2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,4 @@ GEMINI.md
 # Added by user request
 .agent/
 agent.md
+.env

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev test lint format up down init-db smoke
+.PHONY: dev test lint format up down init-db smoke package deploy smoke-prod
 
 PYTHON ?= uv run python
 UVICORN ?= uv run uvicorn
@@ -33,3 +33,29 @@ smoke:
 		-d '{"city":"Austin","state":"TX","latitude":30.27,"longitude":-97.74}' | jq .
 	curl -sf http://localhost:8000/locations \
 		-H "X-Dev-User-Sub: smoke-test" | jq .
+
+# --- Deploy ----------------------------------------------------------
+
+package:
+	./scripts/build_lambda.sh
+
+deploy: package
+	./scripts/deploy.sh
+
+smoke-prod:
+	@if [ -z "$$AUTH0_TOKEN" ]; then \
+		echo "AUTH0_TOKEN env var required."; \
+		exit 1; \
+	fi
+	@API_URL=$$(terraform -chdir=../infra/runtime output -raw api_url); \
+	echo "Smoke testing $$API_URL"; \
+	echo "--- /health (no auth)"; \
+	curl -sf "$$API_URL/health" | jq .; \
+	echo "--- POST /locations"; \
+	curl -sf -X POST "$$API_URL/locations" \
+		-H "Authorization: Bearer $$AUTH0_TOKEN" \
+		-H "Content-Type: application/json" \
+		-d '{"city":"Austin","state":"TX","latitude":30.27,"longitude":-97.74}' | jq .; \
+	echo "--- GET /locations"; \
+	curl -sf "$$API_URL/locations" \
+		-H "Authorization: Bearer $$AUTH0_TOKEN" | jq .

--- a/backend/scripts/build_lambda.sh
+++ b/backend/scripts/build_lambda.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BACKEND_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+STAGING="${BACKEND_DIR}/build/staging"
+ZIP_OUT="${BACKEND_DIR}/build/lambda.zip"
+
+rm -rf "${BACKEND_DIR}/build"
+mkdir -p "${STAGING}"
+
+echo "[build_lambda] Exporting pinned requirements"
+cd "${BACKEND_DIR}"
+uv export \
+  --frozen \
+  --no-dev \
+  --no-emit-project \
+  --format requirements-txt \
+  > "${BACKEND_DIR}/build/requirements.txt"
+
+echo "[build_lambda] Installing deps into staging/"
+uv pip install \
+  --target "${STAGING}" \
+  --requirement "${BACKEND_DIR}/build/requirements.txt" \
+  --python-platform aarch64-manylinux2014 \
+  --python-version 3.12 \
+  --only-binary=:all:
+
+echo "[build_lambda] Copying source"
+cp -R "${BACKEND_DIR}/src/dual_weather" "${STAGING}/dual_weather"
+
+find "${STAGING}" -type d -name '__pycache__' -prune -exec rm -rf {} +
+find "${STAGING}" -name '*.dist-info' -prune -exec rm -rf {} + 2>/dev/null || true
+
+echo "[build_lambda] Zipping"
+cd "${STAGING}"
+zip -qr "${ZIP_OUT}" .
+
+SIZE_KB=$(du -k "${ZIP_OUT}" | cut -f1)
+echo "[build_lambda] Done — ${ZIP_OUT} (${SIZE_KB} KB)"

--- a/backend/scripts/deploy.sh
+++ b/backend/scripts/deploy.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BACKEND_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+INFRA_RUNTIME="${BACKEND_DIR}/../infra/runtime"
+ZIP_PATH="${BACKEND_DIR}/build/lambda.zip"
+
+if [ ! -f "${ZIP_PATH}" ]; then
+  echo "[deploy] ${ZIP_PATH} not found. Run 'make package' first." >&2
+  exit 1
+fi
+
+echo "[deploy] Reading function name from ${INFRA_RUNTIME}"
+FUNCTION_NAME=$(terraform -chdir="${INFRA_RUNTIME}" output -raw function_name)
+REGION="us-east-2"
+
+echo "[deploy] Uploading ${ZIP_PATH} to function ${FUNCTION_NAME} in ${REGION}"
+aws lambda update-function-code \
+  --region "${REGION}" \
+  --function-name "${FUNCTION_NAME}" \
+  --zip-file "fileb://${ZIP_PATH}" \
+  --publish \
+  --output text \
+  --query 'FunctionArn'
+
+echo "[deploy] Waiting for code update to finish"
+aws lambda wait function-updated --region "${REGION}" --function-name "${FUNCTION_NAME}"
+
+echo "[deploy] Ensuring handler is set to dual_weather.main.handler"
+aws lambda update-function-configuration \
+  --region "${REGION}" \
+  --function-name "${FUNCTION_NAME}" \
+  --handler dual_weather.main.handler \
+  --output text \
+  --query 'LastUpdateStatus' > /dev/null
+
+aws lambda wait function-updated --region "${REGION}" --function-name "${FUNCTION_NAME}"
+
+echo "[deploy] Done"

--- a/frontend/Dual Weather iOS/AppConfig.swift
+++ b/frontend/Dual Weather iOS/AppConfig.swift
@@ -1,9 +1,6 @@
 import Foundation
 
-// Update these values after Plan 2 (Terraform) is applied.
-// auth0Audience must match the API identifier in Auth0 dashboard exactly.
-// apiBaseURL comes from `terraform output -raw api_url` in infra/runtime/.
 enum AppConfig {
     static let auth0Audience = "https://api.dualweather/"
-    static let apiBaseURL    = URL(string: "https://placeholder.execute-api.us-east-2.amazonaws.com")!
+    static let apiBaseURL    = URL(string: "https://wkcwz3zjnd.execute-api.us-east-2.amazonaws.com")!
 }

--- a/frontend/Dual Weather iOS/Auth0.plist
+++ b/frontend/Dual Weather iOS/Auth0.plist
@@ -3,8 +3,8 @@
 <plist version="1.0">
 <dict>
     <key>ClientId</key>
-    <string>PLACEHOLDER_CLIENT_ID</string>
+    <string>KYERZtnLvpE4Ban8nu7nmGQSfCTfpaMd</string>
     <key>Domain</key>
-    <string>PLACEHOLDER.us.auth0.com</string>
+    <string>b1codes.us.auth0.com</string>
 </dict>
 </plist>

--- a/infra/.gitignore
+++ b/infra/.gitignore
@@ -11,3 +11,4 @@ override.tf.json
 *_override.tf.json
 .terraformrc
 terraform.rc
+lambda_placeholder.zip

--- a/infra/bootstrap/.terraform.lock.hcl
+++ b/infra/bootstrap/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.70"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/infra/bootstrap/main.tf
+++ b/infra/bootstrap/main.tf
@@ -1,0 +1,41 @@
+resource "aws_s3_bucket" "tfstate" {
+  bucket = var.state_bucket_name
+}
+
+resource "aws_s3_bucket_versioning" "tfstate" {
+  bucket = aws_s3_bucket.tfstate.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "tfstate" {
+  bucket = aws_s3_bucket.tfstate.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "tfstate" {
+  bucket = aws_s3_bucket.tfstate.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_dynamodb_table" "tflock" {
+  name         = var.lock_table_name
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "LockID"
+
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+}

--- a/infra/bootstrap/outputs.tf
+++ b/infra/bootstrap/outputs.tf
@@ -1,0 +1,14 @@
+output "state_bucket_name" {
+  description = "Name of the S3 bucket holding Terraform state."
+  value       = aws_s3_bucket.tfstate.id
+}
+
+output "lock_table_name" {
+  description = "Name of the DynamoDB table used for state locking."
+  value       = aws_dynamodb_table.tflock.name
+}
+
+output "region" {
+  description = "AWS region for state storage."
+  value       = var.region
+}

--- a/infra/platform/.terraform.lock.hcl
+++ b/infra/platform/.terraform.lock.hcl
@@ -1,0 +1,47 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/auth0/auth0" {
+  version     = "1.48.0"
+  constraints = "~> 1.5"
+  hashes = [
+    "h1:uDhDZtoF6ielVHFvXA085sDPy5hYiCw4dBKO11CRA1E=",
+    "zh:02713b9bc12816bb4dbdefea064b3453a1c4a29542a4ee361861cd2d46101b3b",
+    "zh:06b9e4455b4d65ec33381896440b530fbae06a476be200eed92034a8c76010c2",
+    "zh:1f6a935a171cd1c8525100b227de405d2c5d1c9a546e666b91ac89eb8dfc8276",
+    "zh:2778ff4318146cf3cb8a050fa3b85cf31a6dbae32d453c33f4ef3371e6f68800",
+    "zh:39ad0e7c66e65cdd112abfbd2c7d001dc0755400d121c1f189b82b1acf934f43",
+    "zh:4dabc93ca677e0cf12383eaf9a9c08a9173615ca915e63c8689f9e53830cdb5d",
+    "zh:69077a0e27ed773638878cc33caef1cebc086d42a52fbfa754584028c4bf6977",
+    "zh:7eae341f8f919823d6a0506e30429e747aecf8d81aa347144773bcc96ce40ff1",
+    "zh:90a81b4ae4beae76d305a0f027facfe69d0fc15aa25cf65f8fe3839387d67625",
+    "zh:a50d24a84a7f7a69d7de5e1cd038118f349a3d58f6d6d65d3dcf14cfe4bc27ad",
+    "zh:aa398e6aaf351c906423640a13aaa9aaa6eb1566cbada3c375796b69dd93a375",
+    "zh:c64154b7912f50edf163a64af8909e20becace4bfa8955fc24cf676461232fe3",
+    "zh:dd868a563943cccc2a15c37c2858316a4e9a3a2d779666d426e6f2a182da4e10",
+    "zh:e892e1a905924e0f35370c91fdd86fd3b2148e685f94c4749fac6e2400f3ae86",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.70"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/infra/platform/auth0.tf
+++ b/infra/platform/auth0.tf
@@ -1,0 +1,77 @@
+resource "auth0_resource_server" "api" {
+  name        = "Dual Weather API"
+  identifier  = var.auth0_audience
+  signing_alg = "RS256"
+
+  token_lifetime                                  = 86400
+  skip_consent_for_verifiable_first_party_clients = true
+}
+
+resource "auth0_client" "ios_app" {
+  name        = "Dual Weather iOS"
+  description = "Native iOS app for Dual Weather"
+  app_type    = "native"
+
+  is_first_party  = true
+  oidc_conformant = true
+
+  grant_types = [
+    "authorization_code",
+    "refresh_token",
+  ]
+
+  callbacks = [
+    "${var.ios_bundle_id}://${var.auth0_domain}/ios/${var.ios_bundle_id}/callback",
+  ]
+
+  allowed_logout_urls = [
+    "${var.ios_bundle_id}://${var.auth0_domain}/ios/${var.ios_bundle_id}/callback",
+  ]
+
+  refresh_token {
+    rotation_type   = "rotating"
+    expiration_type = "expiring"
+    leeway          = 0
+    token_lifetime  = 2592000
+  }
+
+  jwt_configuration {
+    alg = "RS256"
+  }
+}
+
+resource "auth0_connection" "database" {
+  name     = "Username-Password-Authentication"
+  strategy = "auth0"
+
+  options {
+    password_policy = "good"
+
+    password_complexity_options {
+      min_length = 8
+    }
+
+    brute_force_protection = true
+    disable_signup         = false
+
+    enabled_database_customization = false
+  }
+
+  lifecycle {
+    ignore_changes = [options]
+  }
+}
+
+resource "auth0_connection_clients" "database_to_ios" {
+  connection_id = auth0_connection.database.id
+  enabled_clients = [
+    auth0_client.ios_app.id,
+  ]
+}
+
+resource "auth0_client_grant" "ios_to_api" {
+  client_id = auth0_client.ios_app.id
+  audience  = auth0_resource_server.api.identifier
+
+  scopes = []
+}

--- a/infra/platform/backend.tf
+++ b/infra/platform/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket         = "dual-weather-tfstate-us-east-2"
+    key            = "platform/terraform.tfstate"
+    region         = "us-east-2"
+    dynamodb_table = "dual-weather-tflock"
+    encrypt        = true
+  }
+}

--- a/infra/platform/outputs.tf
+++ b/infra/platform/outputs.tf
@@ -1,0 +1,19 @@
+output "auth0_domain" {
+  description = "Auth0 tenant domain (no scheme, no trailing slash)."
+  value       = var.auth0_domain
+}
+
+output "auth0_native_client_id" {
+  description = "client_id of the Native iOS Auth0 application."
+  value       = auth0_client.ios_app.client_id
+}
+
+output "auth0_audience" {
+  description = "API audience identifier."
+  value       = auth0_resource_server.api.identifier
+}
+
+output "auth0_issuer" {
+  description = "JWT issuer URL — used as the JWT authorizer's issuer URL."
+  value       = "https://${var.auth0_domain}/"
+}

--- a/infra/platform/providers.tf
+++ b/infra/platform/providers.tf
@@ -1,0 +1,17 @@
+provider "aws" {
+  region = var.region
+
+  default_tags {
+    tags = {
+      Project   = "dual-weather"
+      Component = "platform"
+      ManagedBy = "terraform"
+    }
+  }
+}
+
+provider "auth0" {
+  domain        = var.auth0_domain
+  client_id     = var.auth0_client_id
+  client_secret = var.auth0_client_secret
+}

--- a/infra/platform/variables.tf
+++ b/infra/platform/variables.tf
@@ -1,0 +1,33 @@
+variable "region" {
+  description = "AWS region."
+  type        = string
+  default     = "us-east-2"
+}
+
+variable "auth0_domain" {
+  description = "Auth0 tenant domain, e.g. example.us.auth0.com"
+  type        = string
+}
+
+variable "auth0_client_id" {
+  description = "Auth0 Management API M2M client_id used by the Terraform provider."
+  type        = string
+  sensitive   = true
+}
+
+variable "auth0_client_secret" {
+  description = "Auth0 Management API M2M client_secret used by the Terraform provider."
+  type        = string
+  sensitive   = true
+}
+
+variable "auth0_audience" {
+  description = "Identifier (audience) for the Dual Weather API resource server."
+  type        = string
+  default     = "https://api.dualweather/"
+}
+
+variable "ios_bundle_id" {
+  description = "iOS app bundle identifier — used as the custom URL scheme for Auth0 callbacks."
+  type        = string
+}

--- a/infra/platform/versions.tf
+++ b/infra/platform/versions.tf
@@ -6,5 +6,9 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 5.70"
     }
+    auth0 = {
+      source  = "auth0/auth0"
+      version = "~> 1.5"
+    }
   }
 }

--- a/infra/runtime/.terraform.lock.hcl
+++ b/infra/runtime/.terraform.lock.hcl
@@ -1,0 +1,46 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/archive" {
+  version     = "2.8.0"
+  constraints = "~> 2.5"
+  hashes = [
+    "h1:WB6H5ksIZiyq1lQlD/PWeh+tn4FLsbSjVnRW3+4xe2Y=",
+    "zh:0d14713fdc259fb377d0b899ad3c650a34194bd52194c863303ef22a65a580e2",
+    "zh:369b56040c7a8085d04e7e8ffac1e2b321a3170e502f788819bc34b868ec016f",
+    "zh:4d1a3b983ed6af5a52bfe12794674ae55cbadfa6021b37106ade68b433ad216a",
+    "zh:5c547549e26e083573c78a966ca68ce6d7df6bb8f3948f66a575f07da46b74ea",
+    "zh:6de093e62a975eb19a5e3017ce38e6e3cb639c17b79648d2000e0a8348f0e997",
+    "zh:7267936c2cdbc448efeb594d73e6b56a53d6a7ae14fe88cdd2a4133adc3302f0",
+    "zh:7482f023050ed426b4b45116e1761643bc33b1fd4ce4a6fab207ae2571f35940",
+    "zh:76bbd93b234e5a2927d98b511d86565700f549b570871a194c35f944b96cefb7",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:c6afc4bc1f002bac9c173007dd4da05fde788cd14c2916089f958c33fedb0dfa",
+    "zh:d3ba40bd806a3a08e9237dece679193c99afb2085de6b45d7f5d1f673cfcd368",
+    "zh:e1ad7ded53ecd6f0e5b473a3b44eae2b2e885653a56050ab583d387332be02e4",
+    "zh:e93e78575ce82be6084cc153c24ba8f385dc8d6880888ee66e918460c870953d",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.70"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/infra/runtime/apigw.tf
+++ b/infra/runtime/apigw.tf
@@ -1,0 +1,60 @@
+resource "aws_apigatewayv2_api" "main" {
+  name          = "${var.function_name}-api"
+  protocol_type = "HTTP"
+
+  cors_configuration {
+    allow_origins = ["*"]
+    allow_methods = ["GET", "POST", "DELETE", "OPTIONS"]
+    allow_headers = ["authorization", "content-type", "x-dev-user-sub"]
+    max_age       = 3600
+  }
+}
+
+resource "aws_apigatewayv2_authorizer" "jwt" {
+  api_id           = aws_apigatewayv2_api.main.id
+  authorizer_type  = "JWT"
+  name             = "auth0-jwt"
+  identity_sources = ["$request.header.Authorization"]
+
+  jwt_configuration {
+    audience = [data.terraform_remote_state.platform.outputs.auth0_audience]
+    issuer   = data.terraform_remote_state.platform.outputs.auth0_issuer
+  }
+}
+
+resource "aws_apigatewayv2_integration" "lambda" {
+  api_id                 = aws_apigatewayv2_api.main.id
+  integration_type       = "AWS_PROXY"
+  integration_method     = "POST"
+  integration_uri        = aws_lambda_function.api.invoke_arn
+  payload_format_version = "2.0"
+  timeout_milliseconds   = 29000
+}
+
+resource "aws_apigatewayv2_route" "health" {
+  api_id    = aws_apigatewayv2_api.main.id
+  route_key = "GET /health"
+  target    = "integrations/${aws_apigatewayv2_integration.lambda.id}"
+}
+
+resource "aws_apigatewayv2_route" "proxy_jwt" {
+  api_id             = aws_apigatewayv2_api.main.id
+  route_key          = "ANY /{proxy+}"
+  target             = "integrations/${aws_apigatewayv2_integration.lambda.id}"
+  authorization_type = "JWT"
+  authorizer_id      = aws_apigatewayv2_authorizer.jwt.id
+}
+
+resource "aws_apigatewayv2_stage" "default" {
+  api_id      = aws_apigatewayv2_api.main.id
+  name        = "$default"
+  auto_deploy = true
+}
+
+resource "aws_lambda_permission" "apigw" {
+  statement_id  = "AllowAPIGatewayInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.api.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_apigatewayv2_api.main.execution_arn}/*/*"
+}

--- a/infra/runtime/backend.tf
+++ b/infra/runtime/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket         = "dual-weather-tfstate-us-east-2"
+    key            = "runtime/terraform.tfstate"
+    region         = "us-east-2"
+    dynamodb_table = "dual-weather-tflock"
+    encrypt        = true
+  }
+}

--- a/infra/runtime/data.tf
+++ b/infra/runtime/data.tf
@@ -1,0 +1,11 @@
+data "terraform_remote_state" "platform" {
+  backend = "s3"
+
+  config = {
+    bucket = var.state_bucket_name
+    key    = "platform/terraform.tfstate"
+    region = var.region
+  }
+}
+
+data "aws_caller_identity" "current" {}

--- a/infra/runtime/dynamodb.tf
+++ b/infra/runtime/dynamodb.tf
@@ -1,0 +1,24 @@
+resource "aws_dynamodb_table" "main" {
+  name         = var.table_name
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "pk"
+  range_key    = "sk"
+
+  attribute {
+    name = "pk"
+    type = "S"
+  }
+
+  attribute {
+    name = "sk"
+    type = "S"
+  }
+
+  point_in_time_recovery {
+    enabled = true
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}

--- a/infra/runtime/iam.tf
+++ b/infra/runtime/iam.tf
@@ -1,0 +1,39 @@
+data "aws_iam_policy_document" "lambda_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "lambda_exec" {
+  name               = "${var.function_name}-exec"
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume.json
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_basic" {
+  role       = aws_iam_role.lambda_exec.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+data "aws_iam_policy_document" "lambda_dynamodb" {
+  statement {
+    actions = [
+      "dynamodb:GetItem",
+      "dynamodb:PutItem",
+      "dynamodb:DeleteItem",
+      "dynamodb:Query",
+    ]
+    resources = [
+      aws_dynamodb_table.main.arn,
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "lambda_dynamodb" {
+  name   = "${var.function_name}-dynamodb"
+  role   = aws_iam_role.lambda_exec.id
+  policy = data.aws_iam_policy_document.lambda_dynamodb.json
+}

--- a/infra/runtime/lambda.tf
+++ b/infra/runtime/lambda.tf
@@ -1,0 +1,46 @@
+resource "aws_cloudwatch_log_group" "lambda" {
+  name              = "/aws/lambda/${var.function_name}"
+  retention_in_days = var.log_retention_days
+}
+
+data "archive_file" "placeholder" {
+  type        = "zip"
+  source_file = "${path.module}/lambda_placeholder/handler.py"
+  output_path = "${path.module}/lambda_placeholder.zip"
+}
+
+resource "aws_lambda_function" "api" {
+  function_name = var.function_name
+  role          = aws_iam_role.lambda_exec.arn
+  runtime       = "python3.12"
+  architectures = ["arm64"]
+
+  handler = "handler.handler"
+
+  filename         = data.archive_file.placeholder.output_path
+  source_code_hash = data.archive_file.placeholder.output_base64sha256
+
+  timeout     = 10
+  memory_size = 512
+
+  environment {
+    variables = {
+      DW_ENV                  = "prod"
+      DW_TABLE_NAME           = aws_dynamodb_table.main.name
+      DW_AUTH0_DOMAIN         = data.terraform_remote_state.platform.outputs.auth0_domain
+      DW_AUTH0_AUDIENCE       = data.terraform_remote_state.platform.outputs.auth0_audience
+      LOG_LEVEL               = "INFO"
+      POWERTOOLS_SERVICE_NAME = "dual-weather-api"
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      filename,
+      source_code_hash,
+      handler,
+    ]
+  }
+
+  depends_on = [aws_cloudwatch_log_group.lambda]
+}

--- a/infra/runtime/lambda_placeholder/handler.py
+++ b/infra/runtime/lambda_placeholder/handler.py
@@ -1,0 +1,6 @@
+def handler(event, context):
+    return {
+        "statusCode": 500,
+        "body": '{"type":"https://dualweather.app/errors/not-deployed","title":"Backend code not deployed","status":500,"detail":"Run `make deploy` from backend/ to upload real backend code."}',
+        "headers": {"content-type": "application/json"},
+    }

--- a/infra/runtime/outputs.tf
+++ b/infra/runtime/outputs.tf
@@ -1,0 +1,19 @@
+output "api_url" {
+  description = "Base URL of the deployed API."
+  value       = aws_apigatewayv2_api.main.api_endpoint
+}
+
+output "function_name" {
+  description = "Lambda function name — used by backend deploy script."
+  value       = aws_lambda_function.api.function_name
+}
+
+output "table_name" {
+  description = "DynamoDB table name."
+  value       = aws_dynamodb_table.main.name
+}
+
+output "log_group_name" {
+  description = "CloudWatch Log Group for the Lambda."
+  value       = aws_cloudwatch_log_group.lambda.name
+}

--- a/infra/runtime/providers.tf
+++ b/infra/runtime/providers.tf
@@ -1,0 +1,11 @@
+provider "aws" {
+  region = var.region
+
+  default_tags {
+    tags = {
+      Project   = "dual-weather"
+      Component = "runtime"
+      ManagedBy = "terraform"
+    }
+  }
+}

--- a/infra/runtime/variables.tf
+++ b/infra/runtime/variables.tf
@@ -1,0 +1,29 @@
+variable "region" {
+  description = "AWS region."
+  type        = string
+  default     = "us-east-2"
+}
+
+variable "table_name" {
+  description = "DynamoDB table name."
+  type        = string
+  default     = "DualWeather"
+}
+
+variable "function_name" {
+  description = "Lambda function name."
+  type        = string
+  default     = "dual-weather-api"
+}
+
+variable "log_retention_days" {
+  description = "CloudWatch Log Group retention for the Lambda."
+  type        = number
+  default     = 14
+}
+
+variable "state_bucket_name" {
+  description = "S3 bucket holding remote state — must match infra/bootstrap output."
+  type        = string
+  default     = "dual-weather-tfstate-us-east-2"
+}

--- a/infra/runtime/versions.tf
+++ b/infra/runtime/versions.tf
@@ -6,5 +6,9 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 5.70"
     }
+    archive = {
+      source  = "hashicorp/archive"
+      version = "~> 2.5"
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Bootstraps Terraform remote state (S3 + DynamoDB lock) in `us-east-2`
- Provisions Auth0 tenant: native iOS client, email/password DB connection, API resource server (`https://api.dualweather/`), JWT client grant
- Deploys AWS runtime: DynamoDB (`DualWeather` table, PITR on-demand), Lambda (`dual-weather-api`, arm64 Python 3.12), API Gateway HTTP API with Auth0 JWT authorizer, CloudWatch log group (14-day retention)
- Adds `backend/scripts/build_lambda.sh` + `deploy.sh` + Makefile `package`/`deploy`/`smoke-prod` targets
- Updates `Auth0.plist` and `AppConfig.swift` with live credentials — iOS login flow is now testable end-to-end

## Test plan

- [x] `GET /health` → `{"status":"ok"}` (real backend, no auth required)
- [x] `GET /locations` (no token) → HTTP 401 from JWT authorizer (never reaches Lambda)
- [ ] Open app on device → Login screen → tap Continue → Auth0 Universal Login completes → authenticated
- [ ] Save a location → appears in Saved tab
- [ ] Sign out → returns to login screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)